### PR TITLE
Stop pipeline on error and stop running message flows during tests.

### DIFF
--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -520,6 +520,14 @@ spec:
           value: "$(params.serverconf-name)"
         - name: truststore-configuration
           value: "$(params.truststore-name)"
+      when:
+        # --------------------------------------------------------------
+        #  Don't run if the preceding tasks have failed
+        # --------------------------------------------------------------
+        - input: "$(tasks.status)"
+          operator: notin
+          values:
+            - "Failed"
       workspaces:
         - name: output
           workspace: pipeline-shared-workspace

--- a/tekton/tasks/run-tests.yaml
+++ b/tekton/tasks/run-tests.yaml
@@ -94,4 +94,5 @@ spec:
 
         echo "running tests"
         IntegrationServer --work-dir $TEST_SERVER \
-          --test-project $(params.test-project-name)
+          --test-project $(params.test-project-name) \
+          --start-msgflows false 


### PR DESCRIPTION
Generally good for unit test failures to stop the pipeline if possible; I'd considered basing the `when` condition only on the `test` task but couldn't think of a good reason to ignore failures in the other tasks!

Running tests without starting the flows is also a good idea, as keeping the flows stopped avoids them trying to connect to external servers and/or filling the logs with errors. The tests themselves call the code without needing the flows to be started, and the toolkit also runs tests with flows stopped by default.

Signed-off-by: Trevor Dolby <trevor.dolby@ibm.com>